### PR TITLE
Fix elbow calculation for x- to y+ cases, add format script, format

### DIFF
--- a/lib/index.ts
+++ b/lib/index.ts
@@ -44,7 +44,7 @@ export const calculateElbow = (
   const endDir = point2.facingDirection ?? "none"
 
   const push = (pt: { x: number; y: number }) => {
-    const last = result[result.length - 1]
+    const last = result[result.length - 1]!
     if (last.x !== pt.x || last.y !== pt.y) result.push(pt)
   }
 
@@ -69,8 +69,8 @@ export const calculateElbow = (
   } else if (startDir === "x-" && endDir === "x+") {
     if (point1.x > point2.x) {
       //  p1 is right of p2  →  symmetrical “Z” path through the midpoint
-      push({ x: midX, y: point1.y })   // horizontal segment, still in p1’s x- direction
-      push({ x: midX, y: point2.y })   // vertical segment down/up to p2’s y
+      push({ x: midX, y: point1.y }) // horizontal segment, still in p1’s x- direction
+      push({ x: midX, y: point2.y }) // vertical segment down/up to p2’s y
       // final horizontal segment into p2 is produced by the common
       //   push({ x: point2.x, y: point2.y })  at the end of the function
     } else {
@@ -105,9 +105,9 @@ export const calculateElbow = (
     } else {
       // Existing overshoot / U-turn strategy
       const p1OvershootY = point1.y + overshootAmount
-      push({ x: point1.x, y: p1OvershootY })     // move along P1’s y+ direction
-      push({ x: p2Target.x, y: p1OvershootY })   // horizontal to P2’s overshoot X
-      push({ x: p2Target.x, y: point2.y })       // vertical into P2’s Y
+      push({ x: point1.x, y: p1OvershootY }) // move along P1’s y+ direction
+      push({ x: p2Target.x, y: p1OvershootY }) // horizontal to P2’s overshoot X
+      push({ x: p2Target.x, y: point2.y }) // vertical into P2’s Y
     }
   } else if (startDir === "x+" && endDir === "y+") {
     if (point1.x > point2.x && point1.y < point2.y) {
@@ -189,9 +189,9 @@ export const calculateElbow = (
     } else {
       // Overshoot / U-turn fallback (existing behaviour)
       const p1OvershotX = point1.x - overshootAmount
-      push({ x: p1OvershotX, y: point1.y })       // overshoot along x-
-      push({ x: p1OvershotX, y: p2Target.y })     // drop/raise to p2Target.y
-      push({ x: p2Target.x, y: p2Target.y })      // move to p2Target.x at that Y
+      push({ x: p1OvershotX, y: point1.y }) // overshoot along x-
+      push({ x: p1OvershotX, y: p2Target.y }) // drop/raise to p2Target.y
+      push({ x: p2Target.x, y: p2Target.y }) // move to p2Target.x at that Y
     }
   } else if (startDir === "x+" && endDir === "y-") {
     // p1(x,y,x+), p2(x',y',y-). p2 expects approach from y < y' (y+ segment).

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -159,21 +159,25 @@ export const calculateElbow = (
     push({ x: commonX, y: point1.y })
     push({ x: commonX, y: point2.y })
   } else if (startDir === "x-" && endDir === "y+") {
-    // If point1 is facing "x-" and point2.x is to the left of point1.x,
-    // a direct L-bend is possible and preferred.
-    if (point1.x > point2.x) {
+    // When point1 faces left (x-) and point2 expects an approach from below (y+)
+    // we can sometimes take a simple L bend. Otherwise, use an overshoot/U-turn
+    // similar to the logic for the mirrored x+ → y+ case.
+    if (point1.x > point2.x && point1.y > point2.y) {
+      // p1 is right of and below p2 → direct L-bend preferred
       // Path: (p1.x,p1.y) -> (p2.x,p1.y) -> (p2.x,p2.y)
-      // First segment (p1.x,p1.y) -> (p2.x,p1.y) is "x-", matches startDir.
-      // Second segment (p2.x,p1.y) -> (p2.x,p2.y) would be "y-" if p1.y > p2.y (as in elbow14)
-      // or "y+" if p1.y < p2.y.
-      // If the segment is "y-", this is consistent with endDir="y+" (meaning the path,
-      // if it were to continue straight *through* point2, would go in the "y+" direction).
       push({ x: point2.x, y: point1.y })
+    } else if (point1.x > point2.x && point1.y < point2.y) {
+      // p1 is right of and above p2. Mirror of elbow08: overshoot then approach
+      const p1OvershootX = point1.x - overshootAmount
+      push({ x: p1OvershootX, y: point1.y })
+      push({ x: p1OvershootX, y: p2Target.y })
+      push({ x: point2.x, y: p2Target.y })
     } else {
-      // point1.x <= point2.x. point1 facing "x-" must overshoot away from point2.x.
-      // This handles cases like elbow10.
-      push({ x: point1.x - overshootAmount, y: point1.y })
-      push({ x: point1.x - overshootAmount, y: p2Target.y })
+      // point1.x <= point2.x. p1 must move further left before turning
+      // Handles cases like elbow10.
+      const p1OvershootX = point1.x - overshootAmount
+      push({ x: p1OvershootX, y: point1.y })
+      push({ x: p1OvershootX, y: p2Target.y })
       push({ x: point2.x, y: p2Target.y })
     }
   } else if (startDir === "x-" && endDir === "y-") {

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "@types/react-dom": "^19.1.6",
     "react": "^19.1.0",
     "react-dom": "^19.1.0",
-    "tsdown": "^0.12.8"
+    "tsdown": "^0.13.0"
   },
   "peerDependencies": {
     "typescript": "^5"

--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
     "start": "bun run site/index.html",
     "build:lib": "tsdown lib/index.ts --dts --outdir dist",
     "build:site": "bun build site/index.html --outdir site-build",
-    "vercel-build": "bun run build:site"
+    "vercel-build": "bun run build:site",
+    "format": "biome format --write ."
   },
   "devDependencies": {
     "@biomejs/biome": "^2.0.4",

--- a/site/main.tsx
+++ b/site/main.tsx
@@ -22,9 +22,16 @@ const App: React.FC = () => {
     y: 200,
     facingDirection: "y-",
   })
-  const [calculatedElbowPath, setCalculatedElbowPath] = useState<Array<{ x: number; y: number }>>([])
-  const [userLoadedPath, setUserLoadedPath] = useState<Array<{ x: number; y: number }> | null>(null)
-  const [draggingPoint, setDraggingPoint] = useState<"point1" | "point2" | null>(null)
+  const [calculatedElbowPath, setCalculatedElbowPath] = useState<
+    Array<{ x: number; y: number }>
+  >([])
+  const [userLoadedPath, setUserLoadedPath] = useState<Array<{
+    x: number
+    y: number
+  }> | null>(null)
+  const [draggingPoint, setDraggingPoint] = useState<
+    "point1" | "point2" | null
+  >(null)
   const svgRef = useRef<SVGSVGElement>(null)
   const [sceneJsonInput, setSceneJsonInput] = useState("")
   const [pathJsonForTextarea, setPathJsonForTextarea] = useState<string>("")
@@ -33,17 +40,27 @@ const App: React.FC = () => {
     // If point1 or point2 changes, it means user interacted, so clear any loaded path override.
     setUserLoadedPath(null)
 
-    const p1ToUse = { ...point1, facingDirection: point1.facingDirection === "none" ? undefined : point1.facingDirection }
-    const p2ToUse = { ...point2, facingDirection: point2.facingDirection === "none" ? undefined : point2.facingDirection }
-    const newCalculatedPath = calculateElbow(p1ToUse, p2ToUse, { overshoot: OVERSHOOT_AMOUNT })
+    const p1ToUse = { ...point1 }
+    const p2ToUse = { ...point2 }
+    const newCalculatedPath = calculateElbow(p1ToUse, p2ToUse, {
+      overshoot: OVERSHOOT_AMOUNT,
+    })
     setCalculatedElbowPath(newCalculatedPath)
 
     // Update scene JSON input when points change
     setSceneJsonInput(
       JSON.stringify(
         {
-          point1: { x: point1.x, y: point1.y, facingDirection: point1.facingDirection === "none" ? undefined : point1.facingDirection },
-          point2: { x: point2.x, y: point2.y, facingDirection: point2.facingDirection === "none" ? undefined : point2.facingDirection },
+          point1: {
+            x: point1.x,
+            y: point1.y,
+            facingDirection: point1.facingDirection,
+          },
+          point2: {
+            x: point2.x,
+            y: point2.y,
+            facingDirection: point2.facingDirection,
+          },
         },
         null,
         2,
@@ -59,7 +76,9 @@ const App: React.FC = () => {
     setPathJsonForTextarea(JSON.stringify(finalDisplayPath, null, 2))
   }, [finalDisplayPath])
 
-  const getSVGCoordinates = (event: React.MouseEvent): { x: number; y: number } => {
+  const getSVGCoordinates = (
+    event: React.MouseEvent,
+  ): { x: number; y: number } => {
     if (svgRef.current) {
       const svgRect = svgRef.current.getBoundingClientRect()
       return {
@@ -70,26 +89,32 @@ const App: React.FC = () => {
     return { x: 0, y: 0 }
   }
 
-  const handleMouseDown = (pointId: "point1" | "point2", event: React.MouseEvent) => {
+  const handleMouseDown = (
+    pointId: "point1" | "point2",
+    event: React.MouseEvent,
+  ) => {
     event.preventDefault()
     setDraggingPoint(pointId)
   }
 
-  const handleMouseMove = useCallback((event: MouseEvent) => {
-    if (!draggingPoint || !svgRef.current) return
-    let { x, y } = getSVGCoordinates(event as unknown as React.MouseEvent) // Cast needed for global MouseEvent
-    
-    // Snap to grid
-    x = Math.round(x / GRID_SIZE) * GRID_SIZE
-    y = Math.round(y / GRID_SIZE) * GRID_SIZE
+  const handleMouseMove = useCallback(
+    (event: MouseEvent) => {
+      if (!draggingPoint || !svgRef.current) return
+      let { x, y } = getSVGCoordinates(event as unknown as React.MouseEvent) // Cast needed for global MouseEvent
 
-    // Ensure points stay within SVG bounds (optional, but good practice with snapping)
-    x = Math.max(POINT_RADIUS, Math.min(SVG_WIDTH - POINT_RADIUS, x))
-    y = Math.max(POINT_RADIUS, Math.min(SVG_HEIGHT - POINT_RADIUS, y))
+      // Snap to grid
+      x = Math.round(x / GRID_SIZE) * GRID_SIZE
+      y = Math.round(y / GRID_SIZE) * GRID_SIZE
 
-    const updateFn = draggingPoint === "point1" ? setPoint1 : setPoint2
-    updateFn((prevPoint) => ({ ...prevPoint, x, y }))
-  }, [draggingPoint])
+      // Ensure points stay within SVG bounds (optional, but good practice with snapping)
+      x = Math.max(POINT_RADIUS, Math.min(SVG_WIDTH - POINT_RADIUS, x))
+      y = Math.max(POINT_RADIUS, Math.min(SVG_HEIGHT - POINT_RADIUS, y))
+
+      const updateFn = draggingPoint === "point1" ? setPoint1 : setPoint2
+      updateFn((prevPoint) => ({ ...prevPoint, x, y }))
+    },
+    [draggingPoint],
+  )
 
   const handleMouseUp = useCallback(() => {
     setDraggingPoint(null)
@@ -108,7 +133,6 @@ const App: React.FC = () => {
       document.removeEventListener("mouseup", handleMouseUp)
     }
   }, [draggingPoint, handleMouseMove, handleMouseUp])
-
 
   const handleDirectionChange = (
     pointId: "point1" | "point2",
@@ -149,20 +173,28 @@ const App: React.FC = () => {
         }
 
         // Basic validation for facingDirection if present
-        const validDirections: Array<ElbowPoint["facingDirection"] | undefined> = ["x+", "x-", "y+", "y-", undefined]
+        const validDirections: Array<
+          ElbowPoint["facingDirection"] | undefined
+        > = ["x+", "x-", "y+", "y-", undefined]
         if (!validDirections.includes(newPoint1.facingDirection)) {
-            alert("Invalid facingDirection for point1. Allowed values: x+, x-, y+, y- or empty.")
-            return
+          alert(
+            "Invalid facingDirection for point1. Allowed values: x+, x-, y+, y- or empty.",
+          )
+          return
         }
         if (!validDirections.includes(newPoint2.facingDirection)) {
-            alert("Invalid facingDirection for point2. Allowed values: x+, x-, y+, y- or empty.")
-            return
+          alert(
+            "Invalid facingDirection for point2. Allowed values: x+, x-, y+, y- or empty.",
+          )
+          return
         }
 
         setPoint1(newPoint1)
         setPoint2(newPoint2)
       } else {
-        alert("Invalid JSON structure. Expected { point1: {x, y, facingDirection?}, point2: {x, y, facingDirection?} }")
+        alert(
+          "Invalid JSON structure. Expected { point1: {x, y, facingDirection?}, point2: {x, y, facingDirection?} }",
+        )
       }
     } catch (error) {
       alert("Error parsing JSON: " + (error as Error).message)
@@ -179,7 +211,11 @@ const App: React.FC = () => {
       if (
         Array.isArray(parsedPath) &&
         parsedPath.every(
-          (p) => typeof p === "object" && p !== null && typeof p.x === "number" && typeof p.y === "number",
+          (p) =>
+            typeof p === "object" &&
+            p !== null &&
+            typeof p.x === "number" &&
+            typeof p.y === "number",
         )
       ) {
         setUserLoadedPath(parsedPath)
@@ -194,19 +230,43 @@ const App: React.FC = () => {
   }
 
   const renderArrow = (point: ElbowPoint) => {
-    if (!point.facingDirection || point.facingDirection === "none") return null
+    if (!point.facingDirection) return null
     let x2 = point.x
     let y2 = point.y
     switch (point.facingDirection) {
-      case "x+": x2 += ARROW_LENGTH; break
-      case "x-": x2 -= ARROW_LENGTH; break
-      case "y+": y2 += ARROW_LENGTH; break
-      case "y-": y2 -= ARROW_LENGTH; break
+      case "x+":
+        x2 += ARROW_LENGTH
+        break
+      case "x-":
+        x2 -= ARROW_LENGTH
+        break
+      case "y+":
+        y2 += ARROW_LENGTH
+        break
+      case "y-":
+        y2 -= ARROW_LENGTH
+        break
     }
-    return <line x1={point.x} y1={point.y} x2={x2} y2={y2} stroke="blue" strokeWidth="2" markerEnd="url(#arrowhead)" />
+    return (
+      <line
+        x1={point.x}
+        y1={point.y}
+        x2={x2}
+        y2={y2}
+        stroke="blue"
+        strokeWidth="2"
+        markerEnd="url(#arrowhead)"
+      />
+    )
   }
 
-  const directionOptions: FacingDirectionOption[] = ["none", "x+", "x-", "y+", "y-"]
+  const directionOptions: FacingDirectionOption[] = [
+    "none",
+    "x+",
+    "x-",
+    "y+",
+    "y-",
+  ]
 
   return (
     <div>
@@ -216,9 +276,18 @@ const App: React.FC = () => {
           <select
             id="p1-direction"
             value={point1.facingDirection || "none"}
-            onChange={(e) => handleDirectionChange("point1", e.target.value as FacingDirectionOption)}
+            onChange={(e) =>
+              handleDirectionChange(
+                "point1",
+                (e.target as HTMLSelectElement).value as FacingDirectionOption,
+              )
+            }
           >
-            {directionOptions.map(dir => <option key={dir} value={dir}>{dir}</option>)}
+            {directionOptions.map((dir) => (
+              <option key={dir} value={dir}>
+                {dir}
+              </option>
+            ))}
           </select>
         </div>
         <div className="control-group">
@@ -226,16 +295,33 @@ const App: React.FC = () => {
           <select
             id="p2-direction"
             value={point2.facingDirection || "none"}
-            onChange={(e) => handleDirectionChange("point2", e.target.value as FacingDirectionOption)}
+            onChange={(e) =>
+              handleDirectionChange(
+                "point2",
+                (e.target as HTMLSelectElement).value as FacingDirectionOption,
+              )
+            }
           >
-            {directionOptions.map(dir => <option key={dir} value={dir}>{dir}</option>)}
+            {directionOptions.map((dir) => (
+              <option key={dir} value={dir}>
+                {dir}
+              </option>
+            ))}
           </select>
         </div>
       </div>
 
       <svg ref={svgRef} width={SVG_WIDTH} height={SVG_HEIGHT}>
         <defs>
-          <marker id="arrowhead" markerWidth="10" markerHeight="7" refX="0" refY="3.5" orient="auto" preserveAspectRatio="none">
+          <marker
+            id="arrowhead"
+            markerWidth="10"
+            markerHeight="7"
+            refX="0"
+            refY="3.5"
+            orient="auto"
+            preserveAspectRatio="none"
+          >
             {/* preserveAspectRatio="none" might be needed if marker scales unexpectedly due to parent transform */}
             <polygon points="0 0, 10 3.5, 0 7" fill="blue" />
           </marker>
@@ -243,33 +329,37 @@ const App: React.FC = () => {
         {/* Apply Cartesian coordinate system transform */}
         <g transform={`translate(0, ${SVG_HEIGHT}) scale(1, -1)`}>
           {/* Grid Lines */}
-          {Array.from({ length: Math.floor(SVG_WIDTH / GRID_SIZE) -1 }).map((_, i) => (
-            <line
-              key={`v-line-${i}`}
-              x1={(i + 1) * GRID_SIZE}
-              y1="0"
-              x2={(i + 1) * GRID_SIZE}
-              y2={SVG_HEIGHT}
-              stroke="#e0e0e0" // Faded gray
-              strokeWidth="1"
-            />
-          ))}
-          {Array.from({ length: Math.floor(SVG_HEIGHT / GRID_SIZE) - 1 }).map((_, i) => (
-            <line
-              key={`h-line-${i}`}
-              x1="0"
-              y1={(i + 1) * GRID_SIZE}
-              x2={SVG_WIDTH}
-              y2={(i + 1) * GRID_SIZE}
-              stroke="#e0e0e0" // Faded gray
-              strokeWidth="1"
-            />
-          ))}
+          {Array.from({ length: Math.floor(SVG_WIDTH / GRID_SIZE) - 1 }).map(
+            (_, i) => (
+              <line
+                key={`v-line-${i}`}
+                x1={(i + 1) * GRID_SIZE}
+                y1="0"
+                x2={(i + 1) * GRID_SIZE}
+                y2={SVG_HEIGHT}
+                stroke="#e0e0e0" // Faded gray
+                strokeWidth="1"
+              />
+            ),
+          )}
+          {Array.from({ length: Math.floor(SVG_HEIGHT / GRID_SIZE) - 1 }).map(
+            (_, i) => (
+              <line
+                key={`h-line-${i}`}
+                x1="0"
+                y1={(i + 1) * GRID_SIZE}
+                x2={SVG_WIDTH}
+                y2={(i + 1) * GRID_SIZE}
+                stroke="#e0e0e0" // Faded gray
+                strokeWidth="1"
+              />
+            ),
+          )}
 
           {/* Path */}
           {finalDisplayPath.length > 1 && (
             <polyline
-              points={finalDisplayPath.map(p => `${p.x},${p.y}`).join(" ")}
+              points={finalDisplayPath.map((p) => `${p.x},${p.y}`).join(" ")}
               fill="none"
               stroke="black"
               strokeWidth="2"
@@ -283,11 +373,17 @@ const App: React.FC = () => {
                 cx={p.x}
                 cy={p.y}
                 r={POINT_RADIUS}
-                fill={draggingPoint === (index === 0 ? "point1" : "point2") ? "red" : "orange"}
-                onMouseDown={(e) => handleMouseDown(index === 0 ? "point1" : "point2", e)}
+                fill={
+                  draggingPoint === (index === 0 ? "point1" : "point2")
+                    ? "red"
+                    : "orange"
+                }
+                onMouseDown={(e) =>
+                  handleMouseDown(index === 0 ? "point1" : "point2", e)
+                }
                 style={{ cursor: "grab" }}
                 // Vector-effect non-scaling-stroke might be useful if stroke width is affected by scale
-                // vectorEffect="non-scaling-stroke" 
+                // vectorEffect="non-scaling-stroke"
               />
               {renderArrow(p)}
             </g>
@@ -295,29 +391,74 @@ const App: React.FC = () => {
         </g>
       </svg>
 
-      <div style={{ marginTop: "20px", width: "100%", maxWidth: `${SVG_WIDTH}px` }}>
-        <div style={{ display: "flex", justifyContent: "space-between", alignItems: "center", marginBottom: "5px" }}>
-          <label htmlFor="scene-json" style={{ fontWeight: "bold" }}>Scene JSON:</label>
-          <button onClick={handleLoadScene} style={{ padding: "3px 8px" }}>Load</button>
+      <div
+        style={{ marginTop: "20px", width: "100%", maxWidth: `${SVG_WIDTH}px` }}
+      >
+        <div
+          style={{
+            display: "flex",
+            justifyContent: "space-between",
+            alignItems: "center",
+            marginBottom: "5px",
+          }}
+        >
+          <label htmlFor="scene-json" style={{ fontWeight: "bold" }}>
+            Scene JSON:
+          </label>
+          <button onClick={handleLoadScene} style={{ padding: "3px 8px" }}>
+            Load
+          </button>
         </div>
         <textarea
           id="scene-json"
           value={sceneJsonInput}
-          onChange={(e) => setSceneJsonInput(e.target.value)}
-          style={{ width: "100%", height: "150px", fontFamily: "monospace", fontSize: "12px", boxSizing: "border-box" }}
+          onChange={(e) =>
+            setSceneJsonInput((e.target as HTMLTextAreaElement).value)
+          }
+          style={{
+            width: "100%",
+            height: "150px",
+            fontFamily: "monospace",
+            fontSize: "12px",
+            boxSizing: "border-box",
+          }}
         />
       </div>
 
-      <div style={{ marginTop: "20px", width: "100%", maxWidth: `${SVG_WIDTH}px` }}>
-        <div style={{ display: "flex", justifyContent: "space-between", alignItems: "center", marginBottom: "5px" }}>
-          <label htmlFor="path-output" style={{ fontWeight: "bold" }}>Elbow Path Output:</label>
-          <button onClick={handleLoadPathFromJson} style={{ padding: "3px 8px" }}>Load</button>
+      <div
+        style={{ marginTop: "20px", width: "100%", maxWidth: `${SVG_WIDTH}px` }}
+      >
+        <div
+          style={{
+            display: "flex",
+            justifyContent: "space-between",
+            alignItems: "center",
+            marginBottom: "5px",
+          }}
+        >
+          <label htmlFor="path-output" style={{ fontWeight: "bold" }}>
+            Elbow Path Output:
+          </label>
+          <button
+            onClick={handleLoadPathFromJson}
+            style={{ padding: "3px 8px" }}
+          >
+            Load
+          </button>
         </div>
         <textarea
           id="path-output"
           value={pathJsonForTextarea}
-          onChange={(e) => setPathJsonForTextarea(e.target.value)}
-          style={{ width: "100%", height: "150px", fontFamily: "monospace", fontSize: "12px", boxSizing: "border-box" }}
+          onChange={(e) =>
+            setPathJsonForTextarea((e.target as HTMLTextAreaElement).value)
+          }
+          style={{
+            width: "100%",
+            height: "150px",
+            fontFamily: "monospace",
+            fontSize: "12px",
+            boxSizing: "border-box",
+          }}
         />
       </div>
     </div>
@@ -327,5 +468,9 @@ const App: React.FC = () => {
 const container = document.getElementById("root")
 if (container) {
   const root = createRoot(container)
-  root.render(<React.StrictMode><App /></React.StrictMode>)
+  root.render(
+    <React.StrictMode>
+      <App />
+    </React.StrictMode>,
+  )
 }

--- a/tests/elbow03.test.ts
+++ b/tests/elbow03.test.ts
@@ -12,7 +12,7 @@ test("elbow03", () => {
     { x: 0, y: -1 }, // P1 overshoots to (0, -1)
     { x: 1.5, y: -1 }, // Midpoint X, P1 overshot Y
     { x: 1.5, y: 2 }, // Midpoint X, P2 Y (p2EffectiveTargetY is same as p2.y here)
-    { x: 2, y: 2 },   // p2EffectiveTargetX (3 - 1), P2 Y
-    { x: 3, y: 2 },   // Final P2
+    { x: 2, y: 2 }, // p2EffectiveTargetX (3 - 1), P2 Y
+    { x: 3, y: 2 }, // Final P2
   ])
 })

--- a/tests/elbow28.test.ts
+++ b/tests/elbow28.test.ts
@@ -1,0 +1,28 @@
+import { test, expect } from "bun:test"
+import { calculateElbow } from "lib/index"
+
+const scene = {
+  point1: {
+    x: 500,
+    y: 100,
+    facingDirection: "x-",
+  },
+  point2: {
+    x: 300,
+    y: 200,
+    facingDirection: "y+",
+  },
+} as const
+
+test("elbow28", () => {
+  const result = calculateElbow(scene.point1, scene.point2, {
+    overshoot: 50,
+  })
+  expect(result).toEqual([
+    { x: 500, y: 100 },
+    { x: 450, y: 100 },
+    { x: 450, y: 250 },
+    { x: 300, y: 250 },
+    { x: 300, y: 200 },
+  ])
+})

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     // Environment setup & latest features
-    "lib": ["ESNext"],
+    "lib": ["ESNext", "DOM"],
     "target": "ESNext",
     "module": "Preserve",
     "moduleDetection": "force",


### PR DESCRIPTION
## Summary
- handle `x-` to `y+` when start is right and above destination by overshooting
- update `tsdown` to latest version
- add test for overshoot `x-` to `y+` scenario

## Testing
- `bun test tests/elbow28.test.ts`
- `bun test tests`
- `bun update --latest tsdown`
- `bun run format` *(fails: Script not found)*

------
https://chatgpt.com/codex/tasks/task_b_688102ba49ec832e9bfcb115a0a06f86