### PR TITLE
Handle right-above case for y+ to x+ elbows

### DIFF
--- a/lib/index.ts
+++ b/lib/index.ts
@@ -103,11 +103,18 @@ export const calculateElbow = (
       push({ x: point1.x, y: point2.y })
       push({ x: point2.x, y: point2.y })
     } else {
-      // Existing overshoot / U-turn strategy
       const p1OvershootY = point1.y + overshootAmount
-      push({ x: point1.x, y: p1OvershootY }) // move along P1’s y+ direction
-      push({ x: p2Target.x, y: p1OvershootY }) // horizontal to P2’s overshoot X
-      push({ x: p2Target.x, y: point2.y }) // vertical into P2’s Y
+      push({ x: point1.x, y: p1OvershootY })
+      if (point1.x > point2.x && point1.y >= point2.y) {
+        // p1 is to the right of p2; route through the midpoint to
+        // approach p2 from its x+ side without overshooting past it
+        push({ x: midX, y: p1OvershootY })
+        push({ x: midX, y: point2.y })
+      } else {
+        // Existing overshoot / U-turn strategy
+        push({ x: p2Target.x, y: p1OvershootY })
+        push({ x: p2Target.x, y: point2.y })
+      }
     }
   } else if (startDir === "x+" && endDir === "y+") {
     if (point1.x > point2.x && point1.y < point2.y) {

--- a/tests/elbow29.test.ts
+++ b/tests/elbow29.test.ts
@@ -1,0 +1,28 @@
+import { test, expect } from "bun:test"
+import { calculateElbow } from "lib/index"
+
+const scene = {
+  point1: {
+    x: 500,
+    y: 200,
+    facingDirection: "y+",
+  },
+  point2: {
+    x: 250,
+    y: 150,
+    facingDirection: "x+",
+  },
+} as const
+
+test("elbow29", () => {
+  const result = calculateElbow(scene.point1, scene.point2, {
+    overshoot: 50,
+  })
+  expect(result).toEqual([
+    { x: 500, y: 200 },
+    { x: 500, y: 250 },
+    { x: 375, y: 250 },
+    { x: 375, y: 150 },
+    { x: 250, y: 150 },
+  ])
+})


### PR DESCRIPTION
## Summary
- avoid overshooting when path goes from y+ start to x+ end where start lies right/above end
- cover y+ → x+ midpoint routing with unit test

## Testing
- `bun test tests/elbow29.test.ts`
- `bun test tests`


------
https://chatgpt.com/codex/tasks/task_b_688eeab16fcc832e9b3678ecfe8b028d