### PR TITLE
feat: add midline bias option

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ import { calculateElbow } from "calculate-elbow"
 const start = { x: 0, y: 0, facingDirection: "x+" }
 const end = { x: 100, y: 50, facingDirection: "y-" }
 
-const path = calculateElbow(start, end, { overshoot: 20 })
+const path = calculateElbow(start, end, { overshoot: 20, bias: 0.25 })
 console.log(path)
 // [
 //   { x: 0, y: 0 },
@@ -30,7 +30,7 @@ console.log(path)
 // ]
 ```
 
-`calculateElbow` returns an array of points representing the orthogonal segments from start to end. The optional `overshoot` parameter controls how far the path extends beyond the end point when aligning with its facing direction.
+`calculateElbow` returns an array of points representing the orthogonal segments from start to end. The optional `overshoot` parameter controls how far the path extends beyond the end point when aligning with its facing direction. The optional `bias` parameter (from `0` to `1`, default `0.5`) shifts the midline toward `point1` (`0`) or `point2` (`1`).
 
  The function automatically sorts the two input points internally so calculations always proceed from the left-most (and, when tied on `x`, the lowest `y`) point. If the inputs are provided in the opposite order, the resulting array is reversed so the path still runs from the original first point to the second.
 

--- a/lib/calculateElbowBends.ts
+++ b/lib/calculateElbowBends.ts
@@ -29,11 +29,12 @@ export const calculateElbowBends = (
   p1: NormalisedStartPoint,
   p2: ElbowPoint,
   overshootAmount: number,
+  bias: number,
 ): Array<{ x: number; y: number }> => {
   const result: Array<{ x: number; y: number }> = [{ x: p1.x, y: p1.y }]
 
-  const midX = (p1.x + p2.x) / 2
-  const midY = (p1.y + p2.y) / 2
+  const midX = p1.x + (p2.x - p1.x) * bias
+  const midY = p1.y + (p2.y - p1.y) * bias
 
   const p2Target = { x: p2.x, y: p2.y }
   switch (p2.facingDirection) {
@@ -105,10 +106,10 @@ export const calculateElbowBends = (
         push({ x: p1OvershootX, y: p1.y })
         push({ x: p1OvershootX, y: midY })
         push({ x: p2.x, y: midY })
-      // Symmetric case: the start is to the right of the end *and* below it.
-      // We overshoot horizontally from the start and then route vertically
-      // straight to the Y-overshoot of the end point – mirroring the logic
-      // above but for the lower-right quadrant.
+        // Symmetric case: the start is to the right of the end *and* below it.
+        // We overshoot horizontally from the start and then route vertically
+        // straight to the Y-overshoot of the end point – mirroring the logic
+        // above but for the lower-right quadrant.
       } else if (p1.x > p2.x && p1.y > p2.y) {
         const p1OvershootX = p1.x + overshootAmount
         push({ x: p1OvershootX, y: p1.y })

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -15,6 +15,11 @@ export const calculateElbow = (
      * beyond "out" before turning
      */
     overshoot?: number
+    /**
+     * Bias for the midline calculation. 0 biases toward point1, 1 toward
+     * point2.
+     */
+    bias?: number
   } = {},
 ): Array<{ x: number; y: number }> => {
   let p1 = point1
@@ -98,13 +103,15 @@ export const calculateElbow = (
 
   const overshootAmount =
     options?.overshoot ??
-    0.1 *
-      Math.max(Math.abs(rp1.x - rp2.x), Math.abs(rp1.y - rp2.y))
+    0.1 * Math.max(Math.abs(rp1.x - rp2.x), Math.abs(rp1.y - rp2.y))
+
+  const bias = Math.max(0, Math.min(1, options?.bias ?? 0.5))
 
   let result = calculateElbowBends(
     rp1 as NormalisedStartPoint,
     rp2,
     overshootAmount,
+    bias,
   )
 
   if (rotated) {

--- a/site/main.tsx
+++ b/site/main.tsx
@@ -22,6 +22,7 @@ const App: React.FC = () => {
     y: 200,
     facingDirection: "y-",
   })
+  const [bias, setBias] = useState(0.5)
   const [calculatedElbowPath, setCalculatedElbowPath] = useState<
     Array<{ x: number; y: number }>
   >([])
@@ -44,6 +45,7 @@ const App: React.FC = () => {
     const p2ToUse = { ...point2 }
     const newCalculatedPath = calculateElbow(p1ToUse, p2ToUse, {
       overshoot: OVERSHOOT_AMOUNT,
+      bias,
     })
     setCalculatedElbowPath(newCalculatedPath)
 
@@ -66,7 +68,7 @@ const App: React.FC = () => {
         2,
       ),
     )
-  }, [point1, point2])
+  }, [point1, point2, bias])
 
   // Determine the path to display in SVG and to use for the output textarea
   const finalDisplayPath = userLoadedPath || calculatedElbowPath
@@ -308,6 +310,18 @@ const App: React.FC = () => {
               </option>
             ))}
           </select>
+        </div>
+        <div className="control-group">
+          <label htmlFor="bias-slider">Midline Bias: {bias.toFixed(2)}</label>
+          <input
+            id="bias-slider"
+            type="range"
+            min={0}
+            max={1}
+            step={0.01}
+            value={bias}
+            onChange={(e) => setBias(parseFloat(e.target.value))}
+          />
         </div>
       </div>
 

--- a/tests/midlineBias.test.ts
+++ b/tests/midlineBias.test.ts
@@ -1,0 +1,24 @@
+import { test, expect } from "bun:test"
+import { calculateElbow, type ElbowPoint } from "../lib"
+
+test("bias 0 routes via point1 axis", () => {
+  const point1: ElbowPoint = { x: 0, y: 0 }
+  const point2: ElbowPoint = { x: 3, y: 2 }
+  const result = calculateElbow(point1, point2, { bias: 0 })
+  expect(result).toEqual([
+    { x: 0, y: 0 },
+    { x: 0, y: 2 },
+    { x: 3, y: 2 },
+  ])
+})
+
+test("bias 1 routes via point2 axis", () => {
+  const point1: ElbowPoint = { x: 0, y: 0 }
+  const point2: ElbowPoint = { x: 3, y: 2 }
+  const result = calculateElbow(point1, point2, { bias: 1 })
+  expect(result).toEqual([
+    { x: 0, y: 0 },
+    { x: 3, y: 0 },
+    { x: 3, y: 2 },
+  ])
+})


### PR DESCRIPTION
## Summary
- add configurable midline bias to calculateElbow
- expose bias slider in demo UI
- document bias option and cover with tests

## Testing
- `bun test tests`


------
https://chatgpt.com/codex/tasks/task_b_688fed1247ec832e863b41b761e7b0f1