### PR TITLE
fix: stabilize near-aligned elbow routes

### DIFF
--- a/lib/index.ts
+++ b/lib/index.ts
@@ -6,6 +6,11 @@ import {
 
 export type { ElbowPoint }
 
+const COORDINATE_EPSILON = 1e-9
+
+const snapNearlyEqualCoordinates = (value: number, reference: number) =>
+  Math.abs(value - reference) <= COORDINATE_EPSILON ? reference : value
+
 export const calculateElbow = (
   point1: ElbowPoint,
   point2: ElbowPoint,
@@ -17,8 +22,13 @@ export const calculateElbow = (
     overshoot?: number
   } = {},
 ): Array<{ x: number; y: number }> => {
-  let p1 = point1
-  let p2 = point2
+  const originalStart = point1
+  const originalEnd = point2
+  let p1 = { ...point1 }
+  let p2 = {
+    ...point2,
+    y: snapNearlyEqualCoordinates(point2.y, point1.y),
+  }
   let orderFlipped = false
 
   if (p1.x > p2.x || (p1.x === p2.x && p1.y > p2.y)) {
@@ -117,5 +127,12 @@ export const calculateElbow = (
     }))
   }
 
-  return orderFlipped ? result.reverse() : result
+  const orderedResult = orderFlipped ? result.reverse() : result
+  orderedResult[0] = { x: originalStart.x, y: originalStart.y }
+  orderedResult[orderedResult.length - 1] = {
+    x: originalEnd.x,
+    y: originalEnd.y,
+  }
+
+  return orderedResult
 }

--- a/tests/repros/repro02.test.ts
+++ b/tests/repros/repro02.test.ts
@@ -1,0 +1,43 @@
+import { expect, test } from "bun:test"
+import { calculateElbow } from "lib/index"
+
+test("near-aligned perpendicular endpoints route consistently", () => {
+  const result = calculateElbow(
+    {
+      x: -2.025,
+      y: 2.000000000000001,
+      facingDirection: "y+",
+    },
+    {
+      x: -1.1099999999999999,
+      y: 2.0000000000000018,
+      facingDirection: "x-",
+    },
+    {
+      overshoot: 0.2,
+    },
+  )
+
+  expect(result).toEqual([
+    {
+      x: -2.025,
+      y: 2.000000000000001,
+    },
+    {
+      x: -2.025,
+      y: 2.200000000000001,
+    },
+    {
+      x: -1.3099999999999998,
+      y: 2.200000000000001,
+    },
+    {
+      x: -1.3099999999999998,
+      y: 2.000000000000001,
+    },
+    {
+      x: -1.1099999999999999,
+      y: 2.0000000000000018,
+    },
+  ])
+})


### PR DESCRIPTION
Fixes #15

## Summary
- Snap nearly equal Y coordinates during internal elbow calculation to avoid runtime-specific branch differences.
- Preserve the original start/end coordinates in the returned path.
- Add a regression test for the Bun/Node vs browser repro from the issue.

## Verification
- `bun test`
- `bun run build:lib` (passes with existing tsdown config warning)
- `bun x biome check lib\index.ts tests\repros\repro02.test.ts`
- `git diff --check`